### PR TITLE
Add is.call() to parameter validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: streetlightR
 Title: Interact with StreetLight Data's API in R
-Version: 1.2.0
-Date: 2023-12-21
+Version: 1.2.1
+Date: 2023-12-26
 Authors@R: c(
     person("Metropolitan Council", role = "cph"),
     person("Liz", "Roten", , "liz.roten@metc.state.mn.us", role = c("cre", "aut"),

--- a/R/validate_parameters.R
+++ b/R/validate_parameters.R
@@ -40,7 +40,7 @@ validate_parameters <- function(param,
     "metric",
     "country"
   )) {
-    if (!is.character(value)) {
+    if (!is.character(value) & !is.call(value)) {
       cli::cli_abort(paste0(
         "Parameter {param} must be a string."
       ))
@@ -52,7 +52,7 @@ validate_parameters <- function(param,
     "aadt_year",
     "aadt_calibration_year"
   )) {
-    if (!is.numeric(value)) {
+    if (!is.numeric(value) & !is.call(value)) {
       cli::cli_abort(paste0(
         "Parameter {param} must be numeric."
       ))
@@ -75,7 +75,7 @@ validate_parameters <- function(param,
     "enable_completion_email",
     "with_calibration"
   )) {
-    if (!is.logical(value)) {
+    if (!is.logical(value) & !is.call(value)) {
       cli::cli_abort(paste0(
         "Parameter {param} must be a TRUE or FALSE"
       ))

--- a/tests/testthat/test-create_tag.R
+++ b/tests/testthat/test-create_tag.R
@@ -4,5 +4,5 @@ test_that("create tag testing", {
     login_email = test_login,
     "streetlightR"
   ) %>%
-    testthat::expect_warning("Tag names must be case-insensitive unique.")
+    testthat::expect_warning("Tag names must be case-insensitive")
 })


### PR DESCRIPTION
# Fix parameter validation error

Fixes #18 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix 
- [ ] New feature 

# Package development checklist

- [x] `usethis::use_latest_dependencies()`
- [x] `usethis::use_tidy_description()`
- [x] `devtools::test()`
- [x] `devtools::document(roclets = c('rd', 'collate', 'namespace'))`
- [x] Update `DESCRIPTION` with new contributors, if neccessary.
- [x] Double check your documentation
- [x] `styler:::style_active_pkg()`
- [x] `rcmdcheck::rcmdcheck()`
  - fix errors
  - fix simple warnings and notes


## Courtesy checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tagged this PR appropriatley
